### PR TITLE
Update BgApi.cs to not automatically reset device.

### DIFF
--- a/BgApiDriver/BgApi.cs
+++ b/BgApiDriver/BgApi.cs
@@ -91,6 +91,11 @@ namespace BgApiDriver
         public const int EVENT_TIMEOUT_DEFAULT = 1000;
 
         /// <summary>
+        /// Timeout for the open function in seconds.
+        /// </summary>
+        public static int OpenTimeoutInSeconds = 5;
+
+        /// <summary>
         /// Receive buffer.
         /// </summary>
         byte[] m_rx;
@@ -204,7 +209,7 @@ namespace BgApiDriver
             m_serialPort.DataReceived += m_serialDataReceivedEventHandler;
 
             bool deviceFound = false;
-            for (DateTime now = DateTime.Now; DateTime.Now - now < new TimeSpan(0, 0, 5); )
+            for (DateTime now = DateTime.Now; DateTime.Now - now < new TimeSpan(0, 0, OpenTimeoutInSeconds); )
             {
                 try
                 {

--- a/BgApiDriver/BgApi.cs
+++ b/BgApiDriver/BgApi.cs
@@ -20,12 +20,11 @@
  * SOFTWARE.
  */
 using System;
-using System.IO.Ports;
-using System.IO;
-using System.Threading;
 using System.Collections.Generic;
-
+using System.IO;
+using System.IO.Ports;
 using System.Linq;
+using System.Threading;
 
 namespace BgApiDriver
 {
@@ -178,15 +177,18 @@ namespace BgApiDriver
         /// <summary>
         /// Opens the connection to a bgapi device.
         /// </summary>
-        public virtual void Open()
+        public virtual void Open(bool resetUsbDevice = true)
         {
             if (!IsOpen)
             {
                 doOpen();
                 // start with a well known device state
-                ble_cmd_system_reset(0);
-                Close();
-                doOpen();
+                if (resetUsbDevice)
+                {
+                    ble_cmd_system_reset(0);
+                    Close();
+                    doOpen();
+                }
 
                 Info = ble_cmd_system_get_info();
                 log(string.Format("Build: {0}, protocol version: {1}, hardware: {2}", Info.build, Info.protocol_version,


### PR DESCRIPTION
Fix for Issue #7.
It is not necessary to reset the device on every Open, depending on how you workd on it. And it takes a lot of time (5 -6 Seconds) when more than one stick is present, because of the windows serial port Close-Open Issue.
So I made the reset optional. It's backward-compatible, so that existing code should work the same way as before.
Greetings from cologne.